### PR TITLE
fix compilation errors and warning on mac with AppleClang

### DIFF
--- a/cpp/Hsm.hpp
+++ b/cpp/Hsm.hpp
@@ -65,7 +65,8 @@ protected:
     using Event = typename Traits::Host::Event;
 
     template <typename Current>
-    void handleEvent(typename Traits::Host& host, const Current& current, typename Traits::Host::Event event) const
+    void handleEvent([[maybe_unused]] typename Traits::Host& host, [[maybe_unused]] const Current& current,
+                     [[maybe_unused]] typename Traits::Host::Event event) const
     {}
 
 private:
@@ -168,7 +169,7 @@ private:
         // clear all timers associated with this state
         if constexpr (Traits::Host::kClearTimersOnExit)
         {
-            host.template eventScheduler().clearAllTimersInGroup(Traits::kState);
+            host.eventScheduler().clearAllTimersInGroup(Traits::kState);
         }
         if constexpr (Traits::Host::kLogActions == LogActions::eEntryExit)
         {
@@ -286,7 +287,7 @@ private:
         // clear all timers associated with this state
         if constexpr (Traits::Host::kClearTimersOnExit)
         {
-            host.template eventScheduler().clearAllTimersInGroup(Traits::kState);
+            host.eventScheduler().clearAllTimersInGroup(Traits::kState);
         }
         if constexpr (Traits::Host::kLogActions == LogActions::eEntryExit)
         {

--- a/cpp/examples/controller/ExampleControl.hpp
+++ b/cpp/examples/controller/ExampleControl.hpp
@@ -47,7 +47,7 @@ public:
 
     // using Parent = eta_hsm::StateMachine<ExampleControl, ExampleControlTraits>;
 
-    friend class TopState<ExampleControl>;
+    friend struct TopState<ExampleControl>;
 
     using Clock = std::chrono::system_clock;
     using EventScheduler = eta_hsm::utils::TimerBank<eta_hsm::utils::TimerTraits<Clock, Event, StateEnum>>;


### PR DESCRIPTION
AppleClang found a few things to complain about that GCC had been happy enough with.

This now compiles cleanly with both.